### PR TITLE
Warning suppression

### DIFF
--- a/rest/warnings.go
+++ b/rest/warnings.go
@@ -61,6 +61,16 @@ func (NoWarnings) HandleWarningHeader(code int, agent string, message string) {}
 type WarningLogger struct{}
 
 func (WarningLogger) HandleWarningHeader(code int, agent string, message string) {
+	BannedWarnings := []string{
+		"v1 ComponentStatus is deprecated in v1.19+",
+	}
+
+	for i := range BannedWarnings {
+		if BannedWarnings[i] == message {
+			return
+		}
+	}
+
 	if code != 299 || len(message) == 0 {
 		return
 	}


### PR DESCRIPTION
PROBLEM:
Some warnings are displayed to often and we need to supress them while we work on longer term solutions

SOLUTION:
Add a banned message list to the warning call

https://github.com/rancher/rancher/issues/28943
