### PR TITLE
[v1.28] Add k8s v1.28 support

### DIFF
--- a/rest/warnings.go
+++ b/rest/warnings.go
@@ -64,6 +64,16 @@ func (NoWarnings) HandleWarningHeader(code int, agent string, message string) {}
 type WarningLogger struct{}
 
 func (WarningLogger) HandleWarningHeader(code int, agent string, message string) {
+	BannedWarnings := []string{
+		"v1 ComponentStatus is deprecated in v1.19+",
+	}
+
+	for i := range BannedWarnings {
+		if BannedWarnings[i] == message {
+			return
+		}
+	}
+
 	if code != 299 || len(message) == 0 {
 		return
 	}

--- a/tools/cache/shared_informer.go
+++ b/tools/cache/shared_informer.go
@@ -543,7 +543,8 @@ func (s *sharedIndexInformer) AddIndexers(indexers Indexers) error {
 	defer s.startedLock.Unlock()
 
 	if s.started {
-		return fmt.Errorf("informer has already started")
+		s.blockDeltas.Lock()
+		defer s.blockDeltas.Unlock()
 	}
 
 	return s.indexer.AddIndexers(indexers)

--- a/tools/cache/thread_safe_store.go
+++ b/tools/cache/thread_safe_store.go
@@ -270,6 +270,11 @@ func (c *threadSafeMap) Replace(items map[string]interface{}, resourceVersion st
 	c.items = items
 
 	// rebuild any index
+	c.rebuildIndices()
+}
+
+// rebuildIndices rebuilds all indices for the current set c.items. Assumes that c.lock is held by caller
+func (c *threadSafeMap) rebuildIndices() {
 	c.index.reset()
 	for key, item := range c.items {
 		c.index.updateIndices(nil, item, key)
@@ -339,11 +344,16 @@ func (c *threadSafeMap) AddIndexers(newIndexers Indexers) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if len(c.items) > 0 {
-		return fmt.Errorf("cannot add indexers to running index")
+	err := c.index.addIndexers(newIndexers)
+	if err != nil {
+		return err
 	}
 
-	return c.index.addIndexers(newIndexers)
+	if len(c.items) > 0 {
+		c.rebuildIndices()
+	}
+
+	return nil
 }
 
 func (c *threadSafeMap) Resync() error {

--- a/tools/cache/thread_safe_store_test.go
+++ b/tools/cache/thread_safe_store_test.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestThreadSafeStoreDeleteRemovesEmptySetsFromIndex(t *testing.T) {
@@ -191,5 +189,97 @@ func BenchmarkIndexer(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		store.Update(objects[i%objectCount], objects[i%objectCount])
+	}
+}
+
+func TestAddIndexerAfterAdd(t *testing.T) {
+	store := NewThreadSafeStore(Indexers{}, Indices{})
+
+	// Add first indexer
+	err := store.AddIndexers(Indexers{
+		"first": func(obj interface{}) ([]string, error) {
+			value := obj.(string)
+			return []string{
+				value,
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to add first indexer")
+	}
+
+	// Add some data to index
+	store.Add("keya", "value")
+	store.Add("keyb", "value")
+
+	// Assert
+	indexKeys, _ := store.IndexKeys("first", "value")
+	expected := sets.NewString("keya", "keyb")
+	actual := sets.NewString(indexKeys...)
+	if !actual.Equal(expected) {
+		t.Errorf("expected %v does not match actual %v", expected, actual)
+	}
+
+	// Add same indexer, which should fail
+	err = store.AddIndexers(Indexers{
+		"first": func(interface{}) ([]string, error) {
+			return nil, nil
+		},
+	})
+	if err == nil {
+		t.Errorf("Add same index should have failed")
+	}
+
+	// Add new indexer
+	err = store.AddIndexers(Indexers{
+		"second": func(obj interface{}) ([]string, error) {
+			v := obj.(string)
+			return []string{
+				v + "2",
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to add second indexer")
+	}
+
+	// Assert indexers was added
+	if _, ok := store.GetIndexers()["first"]; !ok {
+		t.Errorf("missing indexer first")
+	}
+	if _, ok := store.GetIndexers()["second"]; !ok {
+		t.Errorf("missing indexer second")
+	}
+
+	// Assert existing data is re-indexed
+	indexKeys, _ = store.IndexKeys("first", "value")
+	expected = sets.NewString("keya", "keyb")
+	actual = sets.NewString(indexKeys...)
+	if !actual.Equal(expected) {
+		t.Errorf("expected %v does not match actual %v", expected, actual)
+	}
+	indexKeys, _ = store.IndexKeys("second", "value2")
+	expected = sets.NewString("keya", "keyb")
+	actual = sets.NewString(indexKeys...)
+	if !actual.Equal(expected) {
+		t.Errorf("expected %v does not match actual %v", expected, actual)
+	}
+
+	// Add more data
+	store.Add("keyc", "value")
+	store.Add("keyd", "value")
+
+	// Assert new data is indexed
+	indexKeys, _ = store.IndexKeys("first", "value")
+	expected = sets.NewString("keya", "keyb", "keyc", "keyd")
+	actual = sets.NewString(indexKeys...)
+	if !actual.Equal(expected) {
+		t.Errorf("expected %v does not match actual %v", expected, actual)
+	}
+	indexKeys, _ = store.IndexKeys("second", "value2")
+	expected = sets.NewString("keya", "keyb", "keyc", "keyd")
+	actual = sets.NewString(indexKeys...)
+	if !actual.Equal(expected) {
+		t.Errorf("expected %v does not match actual %v", expected, actual)
 	}
 }


### PR DESCRIPTION
### Related
* https://github.com/rancher/rancher/issues/43109

### Update
* Add v1.28 support till January patches.

### TODO
* [x] A new base branch needs to be created in `rancher/client-go` repo for `release-1.28` using the upstream client go `0.28.6` tag, and then the base branch of this PR needs to be updated with the created branch.
* [x] Remove `WIP` from title once the above point of TODO is completed